### PR TITLE
Add additional package to prevent fail

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -e
-sudo apt-get install -y g++ nasm qemu-system-x86 grub-pc-bin xorriso
+sudo apt-get install -y g++ nasm qemu-system-x86 grub-pc-bin xorriso mtools
 
 # Create build directory
 mkdir -p build


### PR DESCRIPTION
Hey, thanks for making this project! I really love it. I was looking for a good way to mess around with a kernel and then I found your YouTube video when I went to give up and procrasinate. Thanks for you efforts :)

Anyway, the mtools packages I added here is required, if you run the build.sh script without this package, you will run into this error:

grub-mkrescue: error: `mformat` invocation failed
.

After I used sudo apt install mtools on my own machine after reading [this](https://bbs.archlinux.org/viewtopic.php?id=219955) article I found out the issue

Just adding this should make it easier for new people, even though its a simple change I figured why not add it.

Thanks.